### PR TITLE
Account for missing parameter in Request subclass constructors

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -23,7 +23,7 @@ class Request {
 	 * Set up Request with RequestId, timestamp (DateTime) and user (User obj.)
 	 * @param type $data
 	 */
-	public function __construct($rawData, $applicationId) {
+	public function __construct($rawData, $applicationId = NULL) {
 		if (!is_string($rawData)) {
 			throw new InvalidArgumentException('Alexa Request requires the raw JSON data to validate request signature');
 		}
@@ -37,7 +37,9 @@ class Request {
 		$this->timestamp = new DateTime($data['request']['timestamp']);
 		$this->session = new Session($data['session']);
 
-		$this->applicationId = $applicationId;
+		$this->applicationId = (is_null($applicationId) && isset($data['session']['application']['applicationId']))
+			? $data['session']['application']['applicationId']
+			: $applicationId;
 
 	}
 


### PR DESCRIPTION
This was causing PHP warnings when creating a more specialized request object using 
`$request->fromData()`.
